### PR TITLE
Fix 85 missing dependencies in Makefile with Auto Dep Generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,3 @@ clean:
 %.d: %.c
 	$(CC) $(CFLAGS) -MM -MT"$@ $(@:.d=.o)" -MP -MF $@ $<
 
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,12 @@ OBJS = Embedded/common/src/b_APIEm/DCR.o \
        FaceRecEm/common/src/b_FDSDK/SDK.o \
        neven.o
 
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.o,%.d, $(OBJS))
+
+# include by auto dependencies
+-include $(AUTODEPS)
+
 all: libneven.so
 
 libneven.so: $(OBJS)
@@ -112,4 +118,14 @@ uninstall:
 
 clean:
 	$(RM) -f $(OBJS) libneven.so
+	${RM} -f $(AUTODEPS)
+
+%.o: %.c %.d
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.d: %.c
+	$(CC) $(CFLAGS) -MM -MT"$@ $(@:.d=.o)" -MP -MF $@ $<
+
+
+
 


### PR DESCRIPTION
Deas LS, 

We have found and fixed 85 dependency issues in the Makefile.
Those issues can cause incorrect results when the project is incrementally built.
For example, any changes in a header file will not cause the object file to be rebuilt, which is incorrect.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

I fix them by using the Auto-Dependency Generation technique mentioned here: http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/

Thanks
Vemake 